### PR TITLE
Use head ref for PRs

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -12709,10 +12709,14 @@ const [, , repoOrg, repoName] = pattern.exec(payload.repository.url);
 (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Org: ${repoOrg}`);
 (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`Repo: ${repoName}`);
 const ref = _actions_github__WEBPACK_IMPORTED_MODULE_1__.context.ref;
+const headRef = process.env.GITHUB_HEAD_REF;
 
 const getBranch = () => {
   if (ref.startsWith("refs/heads/")) {
     return ref.substring(11);
+  } else if (ref.startsWith("refs/pull/") && headRef) {
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`This is a PR. Using head ref ${headRef} instead of ${ref}`);
+    return headRef;
   }
   return ref;
 };

--- a/index.js
+++ b/index.js
@@ -17,10 +17,14 @@ info(`URL: ${payload.repository.url}`);
 info(`Org: ${repoOrg}`);
 info(`Repo: ${repoName}`);
 const ref = context.ref;
+const headRef = process.env.GITHUB_HEAD_REF;
 
 const getBranch = () => {
   if (ref.startsWith("refs/heads/")) {
     return ref.substring(11);
+  } else if (ref.startsWith("refs/pull/") && headRef) {
+    info(`This is a PR. Using head ref ${headRef} instead of ${ref}`);
+    return headRef;
   }
   return ref;
 };


### PR DESCRIPTION
When triggering CircleCI pipelines on PR events, the branch that is sent to CCI is `refs/pull/<pr#>` but nobody needs/cares about that ref.  Instead the head ref should be sent which is the branch name (minus `refs/heads`) that is being merged into the PR base branch.