### PR TITLE
docs: Move when clause under workflow declaration—not workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ workflows:
   # This workflow is set to be conditionally triggered,
   # only via the GitHub Action.
   # With no other unfiltered workflows, normal push events will be ignored.
-  when: << pipeline.parameters.GHA_Action >>
   test:
+    when: << pipeline.parameters.GHA_Action >>
     jobs:
       - test
 ```


### PR DESCRIPTION
This pull request makes a minor documentation fix. The placement of the when clause should go under the test workflow—not workflows. Check out https://circleci.com/docs/2.0/pipeline-variables/#conditional-workflows for more details.