### PR TITLE
docs: add job filters on release job workflow

### DIFF
--- a/examples/02-Trigger-Workflow-On-Release/.circleci/config.yml
+++ b/examples/02-Trigger-Workflow-On-Release/.circleci/config.yml
@@ -34,3 +34,7 @@ workflows:
       equal: [ "release", << pipeline.parameters.GHA_Event >> ]
     jobs:
       - release
+          # This is mandatory to trigger a pipeline when pushing a tag
+          filters:
+            tags:
+                only: /.*/


### PR DESCRIPTION
The API request worked on CircleCI pipeline but a `No workflow` status was shown.
For tag push CircleCI need the filters parameter.

As I understand, the triggering event from this github action is a tag event. That's why we need this filter now.