### PR TITLE
feature: Add CCI_HOST env to allow configurable host

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ import axios from "axios";
 startGroup("Preparing CircleCI Pipeline Trigger");
 const repoOrg = context.repo.owner;
 const repoName = context.repo.repo;
+const host = `${process.env.CCI_HOST}` || "circleci.com";
 info(`Org: ${repoOrg}`);
 info(`Repo: ${repoName}`);
 const ref = context.ref;
@@ -63,7 +64,7 @@ if (tag) {
   Object.assign(body, { branch });
 }
 
-const url = `https://circleci.com/api/v2/project/gh/${repoOrg}/${repoName}/pipeline`;
+const url = `https://${host}/api/v2/project/gh/${repoOrg}/${repoName}/pipeline`;
 
 info(`Triggering CircleCI Pipeline for ${repoOrg}/${repoName}`);
 info(`Triggering URL: ${url}`);


### PR DESCRIPTION
Fixes #34 

This would enable support for CircleCI enterprise users to use this GH action by adding a configurable host via a `CCI_HOST` key. If no host is defined, it would fallback to `circleci.com`