### PR TITLE
build(hooks): add the transcompiled files in dist/ to the pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 npm run lint && npm run format && npm run build
+git add dist/


### PR DESCRIPTION
## Currently
The pre-commit hook transcompiles the ECMA scripts into JavaScript, but doesn't add it while the commit is in progress. I can't find any documentation or conversation about this, so it's unclear if this was intentional.

## Problem
This requires us to create an additional commit after our source-commit to include the build.

## Solution
Modify the pre-commit hook to add the transcompiled code to the commit that is in progress.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our contributor [guidelines](https://github.com/CircleCI-Public/circleci-config-sdk-ts/blob/main/CONTRIBUTING.md).
- [ ] ~Tests for the changes have been added (for bug fixes / features)~ _**There are no test cases included in this project. I planned on bringing that up as a separate topic.**_
- [ ] ~Documentation has been added or updated where needed.~ _**Please let me know if a documentation change is necessary.**_

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix _**...possibly?**_
- [x] Feature _**...possibly?**_
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes _**Specifically, the build process.**_
- [ ] CI related changes
- [ ] Other... Please describe:

> more details

## What issues are resolved by this PR?
<!-- All Pull Requests should be a response to an existing issue. Please ensure you have created an issue before submitting a PR. -->
- #45

## Describe the new behavior.
When committing source changes, the build will now be included automatically by the pre-commit hook.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No **_I don't believe this should be a breaking change._**