### PR TITLE
feat(outputs): set pipeline POST response data as GitHub Action outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ jobs:
           CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
 ```
 
+# Outputs
+
+Field | Data Type | Description
+-- | -- | --
+`id` | string (uuid) | The unique ID of the pipeline.
+`state` | string (Enum: "created" "errored" "setup-pending" "setup" "pending") | The current state of the pipeline.
+`number` | integer (int64) | The number of the pipeline.
+`created_at` | string (date-time) | The date and time the pipeline was created.
+
 # Things To Know
 
 ## GitHub Actions runs _alongside_ native CircleCI integration.

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,15 @@ inputs:
   GHA_Meta:
     required: false
     description: 'An optional additional metadata parameter. Will be available on the CircleCI pipeline as GHA_Meta'
+outputs:
+  id:
+    description: The unique ID of the pipeline.
+  state:
+    description: The current state of the pipeline.
+  number:
+    description: The number of the pipeline.
+  created_at:
+    description: The date and time the pipeline was created.
 runs:
   using: 'node16'
   main: 'dist/index.js'

--- a/dist/index.js
+++ b/dist/index.js
@@ -16558,6 +16558,10 @@ axios__WEBPACK_IMPORTED_MODULE_2___default().post(url, body, { headers: headers 
   .then((response) => {
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.startGroup)("Successfully triggered CircleCI Pipeline");
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.info)(`CircleCI API Response: ${JSON.stringify(response.data)}`);
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("created_at", response.data.created_at);
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("id", response.data.id);
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("number", response.data.number);
+    (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput)("state", response.data.state);
     (0,_actions_core__WEBPACK_IMPORTED_MODULE_0__.endGroup)();
   })
   .catch((error) => {

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import {
   getInput,
   setFailed,
+  setOutput,
   startGroup,
   endGroup,
   info,
@@ -81,6 +82,10 @@ axios
   .then((response) => {
     startGroup("Successfully triggered CircleCI Pipeline");
     info(`CircleCI API Response: ${JSON.stringify(response.data)}`);
+    setOutput("created_at", response.data.created_at);
+    setOutput("id", response.data.id);
+    setOutput("number", response.data.number);
+    setOutput("state", response.data.state);
     endGroup();
   })
   .catch((error) => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our contributor [guidelines](https://github.com/CircleCI-Public/circleci-config-sdk-ts/blob/main/CONTRIBUTING.md).
- [ ] ~Tests for the changes have been added (for bug fixes / features)~
- [x] Documentation has been added or updated where needed.

## PR Type
What kind of change does this PR introduce?

- [ ] Bug fix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What issues are resolved by this PR?
- #28

## Describe the new behavior.
Implements the description outlined in #28 to add Outputs to the GitHub Action in order to enable downstream projects to pull the pipeline number and id.

#### Example GitHub Job Steps
```yaml
      - name: Deploying to ${{ inputs.environment_name }} with CircleCI Pipeline
        id: cci_pipeline
        uses:  snapsheet/trigger-circleci-pipeline-action@add_pipeline_request_outputs
        with:
          GHA_Data: ${{ toJSON(inputs) }}
          GHA_Meta: ${{ inputs.environment_name }}
          CCI_Context: ${{ fromJson(steps.environment_config.outputs.json_string).context }}
        env:
          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
          CCI_HOST: circleci.com # ...now required...?

      - name: Check CircleCI Outputs
        run: |
          echo "id: ${{ steps.cci_pipeline.outputs.id }}"
          echo "state: ${{ steps.cci_pipeline.outputs.state }}"
          echo "created_at: ${{ steps.cci_pipeline.outputs.created_at }}"
          echo "number: ${{ steps.cci_pipeline.outputs.number }}"
```

You should now see the outputs in your run logs:
> Successfully triggered CircleCI Pipeline
Run echo "id: 0f1c3884-fa98-4b9d-a95d-b473dd398cf1"
id: 0f1c3884-fa98-4b9d-a95d-b473dd398cf1
state: pending
created_at: 2023-03-22T19:08:10.214Z
number: 1298

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
