### PR TITLE
feat: trigger external repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,26 @@ jobs:
           CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
 ```
 
+### target-slug
+
+**required:** false
+
+**description**: The [CircleCI project slug](https://circleci.com/docs/api-developers-guide/#github-and-bitbucket-projects) of the target project (ex: `github/<org>/<repo>`). If not specified, the slug of the current GitHub repository will be used.
+
+```yaml
+jobs:
+  trigger-circleci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: <customize name>
+        id: <customize id>
+        uses: CircleCI-Public/trigger-circleci-pipeline-action@v1.0.5
+        with:
+          target-slug: "gh/<org>/<repo>" # Will trigger the pipeline for external project
+        env:
+          CCI_TOKEN: ${{ secrets.CCI_TOKEN }}
+```
+
 # Outputs
 
 Field | Data Type | Description

--- a/action.yml
+++ b/action.yml
@@ -6,16 +6,16 @@ branding:
 inputs:
   GHA_Meta:
     required: false
-    description: 'An optional additional metadata parameter. Will be available on the CircleCI pipeline as GHA_Meta'
+    description: 'An optional additional metadata parameter. Will be available on the CircleCI pipeline as GHA_Meta.'
   target-slug:
     required: false
-    description: 'The slug of the target CircleCI project. For example, "github/<org>/<project>". Will default to the current project.'
+    description: 'The slug of the target CircleCI project. For example, "github/<org>/<project>". Will default to the current project. Can be overwritten with "TARGET_SLUG" environment variable.'
   target-branch:
     required: false
-    description: 'The branch of the target CircleCI project. Will default to the current branch name. This should be overwritten if "target-slug" is set.'
+    description: 'The branch of the target CircleCI project. Will default to the current branch name. This should be overwritten if "target-slug" is set. Can be overwritten with "TARGET_BRANCH" environment variable.'
   target-tag:
     required: false
-    description: 'The tag of the target CircleCI project. Will default to the current tag name if set. This or branch should be overwritten if "target-slug" is set.'
+    description: 'The tag of the target CircleCI project. Will default to the current tag name if set. This or branch should be overwritten if "target-slug" is set. Can be overwritten with "TARGET_TAG" environment variable.'
 outputs:
   id:
     description: The unique ID of the pipeline.

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,15 @@ inputs:
   GHA_Meta:
     required: false
     description: 'An optional additional metadata parameter. Will be available on the CircleCI pipeline as GHA_Meta'
+  target-slug:
+    required: false
+    description: 'The slug of the target CircleCI project. For example, "github/<org>/<project>". Will default to the current project.'
+  target-branch:
+    required: false
+    description: 'The branch of the target CircleCI project. Will default to the current branch name. This should be overwritten if "target-slug" is set.'
+  target-tag:
+    required: false
+    description: 'The tag of the target CircleCI project. Will default to the current tag name if set. This or branch should be overwritten if "target-slug" is set.'
 outputs:
   id:
     description: The unique ID of the pipeline.

--- a/dist/index.js
+++ b/dist/index.js
@@ -16275,8 +16275,10 @@ const { owner, repo } = github_1.context.repo;
 const host = process.env.CCI_HOST || "circleci.com";
 const url = `https://${host}/api/v2/project/gh/${owner}/${repo}/pipeline`;
 const metaData = (0, core_1.getInput)("GHA_Meta");
-const tag = getTag(github_1.context.ref);
-const branch = getBranch(github_1.context.ref);
+const tag = process.env.TARGET_TAG ?? (0, core_1.getInput)("target-tag") ?? getTag(github_1.context.ref);
+const branch = process.env.TARGET_BRANCH ??
+    (0, core_1.getInput)("target-branch") ??
+    getBranch(github_1.context.ref);
 const parameters = {
     GHA_Actor: github_1.context.actor,
     GHA_Action: github_1.context.action,

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,10 +36,12 @@ const parseSlug = (slug: string) => {
     throw new Error(`Invalid target-slug: ${slug}`);
   }
   return { vcs, owner, repo };
-}
+};
 
 const slug = process.env.TARGET_SLUG ?? getInput("target-slug");
-const { vcs, owner, repo } = slug ? parseSlug(slug) : {...context.repo, vcs: "gh"};
+const { vcs, owner, repo } = slug
+  ? parseSlug(slug)
+  : { ...context.repo, vcs: "gh" };
 const host = process.env.CCI_HOST || "circleci.com";
 const url = `https://${host}/api/v2/project/${vcs}/${owner}/${repo}/pipeline`;
 const metaData = getInput("GHA_Meta");

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,12 +30,25 @@ const getBranch = (ref: string) => {
   return ref;
 };
 
-const { owner, repo } = context.repo;
+const parseSlug = (slug: string) => {
+  const [vcs, owner, repo] = slug.split("/");
+  if (!owner || !repo || !vcs) {
+    throw new Error(`Invalid target-slug: ${slug}`);
+  }
+  return { vcs, owner, repo };
+}
+
+const slug = process.env.TARGET_SLUG ?? getInput("target-slug");
+const { vcs, owner, repo } = slug ? parseSlug(slug) : {...context.repo, vcs: "gh"};
 const host = process.env.CCI_HOST || "circleci.com";
-const url = `https://${host}/api/v2/project/gh/${owner}/${repo}/pipeline`;
+const url = `https://${host}/api/v2/project/${vcs}/${owner}/${repo}/pipeline`;
 const metaData = getInput("GHA_Meta");
-const tag = getTag(context.ref);
-const branch = getBranch(context.ref);
+const tag =
+  process.env.TARGET_TAG ?? getInput("target-tag") ?? getTag(context.ref);
+const branch =
+  process.env.TARGET_BRANCH ??
+  getInput("target-branch") ??
+  getBranch(context.ref);
 const parameters: CircleCIPipelineParams = {
   GHA_Actor: context.actor,
   GHA_Action: context.action,


### PR DESCRIPTION
Aims to resolve #14 by enabling the action to trigger additional CircleCI projects beyond the current repository.

This is useful, for instance, if you have a remote repository set to build on the latest version of a docker image, you can use this action in the repo which builds the docker image, to test it with the remote repository immediately.

## New optional inputs

```yaml
  target-slug:
    required: false
    description: 'The slug of the target CircleCI project. For example, "github/<org>/<project>". 
Will default to the current project. Can be overwritten with "TARGET_SLUG" environment variable.'
  target-branch:
    required: false
    description: 'The branch of the target CircleCI project. Will default to the current branch name. 
This should be overwritten if "target-slug" is set. Can be overwritten with "TARGET_BRANCH" environment variable.'
  target-tag:
    required: false
    description: 'The tag of the target CircleCI project. Will default to the current tag name if set. 
This or branch should be overwritten if "target-slug" is set. Can be overwritten with "TARGET_TAG" environment variable.'
```