### PR TITLE
ci: Upgrade node from 16 to 20.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -26,5 +26,5 @@ outputs:
   created_at:
     description: The date and time the pipeline was created.
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
The GitHub 'node16' CI infrastructure is going away this spring:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

Fixes #74