### PR TITLE
Add GHA_Actor parameter to allow user's override

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   GHA_Meta:
     required: false
     description: 'An optional additional metadata parameter. Will be available on the CircleCI pipeline as GHA_Meta.'
+  GHA_Actor:
+    required: false
+    description: 'An optional additional metadata parameter. Will be available on the CircleCI pipeline as GHA_Actor.'
   target-slug:
     required: false
     description: 'The slug of the target CircleCI project. For example, "github/<org>/<project>". Will default to the current project. Can be overwritten with "TARGET_SLUG" environment variable.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -16270,7 +16270,7 @@ class CircleCIPipelineTrigger {
         this.tag = this.getTag();
         this.branch = this.getBranch();
         this.parameters = {
-            GHA_Actor: context.actor,
+            GHA_Actor: (0, core_1.getInput)("GHA_Actor") ?? context.actor,
             GHA_Action: context.action,
             GHA_Event: context.eventName,
         };

--- a/src/lib/CircleCIPipelineTrigger.ts
+++ b/src/lib/CircleCIPipelineTrigger.ts
@@ -37,7 +37,7 @@ export class CircleCIPipelineTrigger {
     this.tag = this.getTag();
     this.branch = this.getBranch();
     this.parameters = {
-      GHA_Actor: context.actor,
+      GHA_Actor: getInput("GHA_Actor") ?? context.actor,
       GHA_Action: context.action,
       GHA_Event: context.eventName,
     };


### PR DESCRIPTION
Hello, dear maintainers,

I ran into the issue when my CircleCI's job was triggered from the PR created by [dependabot](https://docs.github.com/en/code-security/dependabot/working-with-dependabot) but failed because dependabot is not known to CircleCI.
When the same job is triggered with `GHA_Actor`, an existing user, it passes.

To overcome this issue, I added `GHA_Actor` as a parameter so that users could override it if needed.

I didn't touch documentation much, but I am open to any suggestions.
Thanks a lot for your time and support!